### PR TITLE
CHECKOUT-1123: fix customizing form fields

### DIFF
--- a/assets/scss/checkout.scss
+++ b/assets/scss/checkout.scss
@@ -77,7 +77,13 @@ a {
 }
 
 // Form Fields
-.form-legend,
-.form-body {
+.form-input,
+.form-select {
     background-color: stencilString("uco_form-field_backgroundColor");
+}
+
+.form-select {
+    &:hover {
+        background-color: stencilString("uco_form-field_backgroundColor");
+    }
 }


### PR DESCRIPTION
fix class names that effect background color changes of form field elements

<img width="1429" alt="screen shot 2016-10-10 at 1 43 56 pm" src="https://cloud.githubusercontent.com/assets/8165665/19250530/9eb4f3b6-8eef-11e6-9574-455a40ec2ea3.png">

@bigcommerce/checkout @bc-miko-ademagic
