### PR TITLE
CHECKOUT-1145: allow for customizing background-color of checkout-modal

### DIFF
--- a/assets/scss/checkout.scss
+++ b/assets/scss/checkout.scss
@@ -22,8 +22,11 @@
     background-color: stencilColor("checkout_main_backgroundColor");
 }
 
-// Order Summary
-.cart {
+// Order Summary, Mobile Order Summary, Modal Order Summary
+.cart,
+.cartDrawer,
+.cart-modal-body,
+.cart-modal-header {
     background-color: stencilColor("checkout_cart_backgroundColor");
 }
 


### PR DESCRIPTION
customize cart drawer and cart modal background-color that corresponds with `cart summary`

<img width="1416" alt="screen shot 2016-10-18 at 2 23 23 pm" src="https://cloud.githubusercontent.com/assets/8165665/19496963/e0c6e354-953e-11e6-8576-e5cdd0373568.png">
<img width="727" alt="screen shot 2016-10-18 at 2 23 28 pm" src="https://cloud.githubusercontent.com/assets/8165665/19496966/e0df0aa6-953e-11e6-9012-01826a065bf7.png">
<img width="636" alt="screen shot 2016-10-18 at 2 23 33 pm" src="https://cloud.githubusercontent.com/assets/8165665/19496965/e0dba06e-953e-11e6-8e18-e381b833c729.png">

@icatalina @davidchin @bigcommerce/checkout
